### PR TITLE
Fix rating icons on chrome

### DIFF
--- a/icons/climacon-clear-night.svg
+++ b/icons/climacon-clear-night.svg
@@ -21,6 +21,7 @@
             -moz-transform-origin: 50% 50%;
             -o-transform-origin: 50% 50%;
             transform-origin: 50% 50%;
+            transform-box: fill-box;
 
             -webkit-animation-timing-function: linear;
             -moz-animation-timing-function: linear;

--- a/icons/climacon-few-showers.svg
+++ b/icons/climacon-few-showers.svg
@@ -20,6 +20,7 @@
             -moz-transform-origin: 50% 50%;
             -o-transform-origin: 50% 50%;
             transform-origin: 50% 50%;
+            transform-box: fill-box;
 
             -webkit-animation-iteration-count: infinite;
             -moz-animation-iteration-count: infinite;

--- a/icons/climacon-mostly-cloudy-day.svg
+++ b/icons/climacon-mostly-cloudy-day.svg
@@ -21,6 +21,7 @@
             -moz-transform-origin: 50% 50%;
             -o-transform-origin: 50% 50%;
             transform-origin: 50% 50%;
+            transform-box: fill-box;
 
             -webkit-animation-iteration-count: infinite;
             -moz-animation-iteration-count: infinite;

--- a/icons/climacon-mostly-cloudy-night.svg
+++ b/icons/climacon-mostly-cloudy-night.svg
@@ -21,6 +21,7 @@
             -moz-transform-origin: 50% 50%;
             -o-transform-origin: 50% 50%;
             transform-origin: 50% 50%;
+            transform-box: fill-box;
 
             -webkit-animation-iteration-count: infinite;
             -moz-animation-iteration-count: infinite;

--- a/icons/climacon-partly-cloudy-day.svg
+++ b/icons/climacon-partly-cloudy-day.svg
@@ -21,6 +21,7 @@
                 -moz-transform-origin: 50% 50%;
                 -o-transform-origin: 50% 50%;
                 transform-origin: 50% 50%;
+                transform-box: fill-box;
 
                 -webkit-animation-iteration-count: infinite;
                 -moz-animation-iteration-count: infinite;

--- a/icons/climacon-partly-cloudy-night.svg
+++ b/icons/climacon-partly-cloudy-night.svg
@@ -21,6 +21,7 @@
             -moz-transform-origin: 50% 50%;
             -o-transform-origin: 50% 50%;
             transform-origin: 50% 50%;
+            transform-box: fill-box;
 
             -webkit-animation-iteration-count: infinite;
             -moz-animation-iteration-count: infinite;

--- a/icons/climacon-snow-flurries.svg
+++ b/icons/climacon-snow-flurries.svg
@@ -36,6 +36,8 @@
             animation-timing-function: linear;
             animation-duration: 12s;
             animation-direction: normal;
+            transform-box: fill-box;
+
         }
 
         .climacon_component-snowAlt {

--- a/icons/climacon-sunny.svg
+++ b/icons/climacon-sunny.svg
@@ -21,6 +21,7 @@
             -moz-transform-origin: 50% 50%;
             -o-transform-origin: 50% 50%;
             transform-origin: 50% 50%;
+            transform-box: fill-box;
 
             -webkit-animation-timing-function: linear;
             -moz-animation-timing-function: linear;

--- a/icons/climacon-thundershowers.svg
+++ b/icons/climacon-thundershowers.svg
@@ -20,6 +20,7 @@
             -moz-transform-origin: 50% 50%;
             -o-transform-origin: 50% 50%;
             transform-origin: 50% 50%;
+            transform-box: fill-box;
 
             -webkit-animation-iteration-count: infinite;
             -moz-animation-iteration-count: infinite;


### PR DESCRIPTION
Added the "transform-box: fill-box" to rotating icons to keep them in place rather than rotate around the box.