### PR TITLE
Update to OpenHAB 2.5.0

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.openhab.ui.iconset.climacons
 Bundle-Version: 2.3.0.qualifier
 Bundle-Vendor: openhab.org
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
-Import-Package: org.eclipse.smarthome.core.i18n,
+Import-Package: org.eclipse.smarthome.i18n,
  org.eclipse.smarthome.ui.icon,
  org.osgi.framework,
  org.slf4j


### PR DESCRIPTION
Rename Import-Package: org.eclipse.smarthome.core.i18n to org.eclipse.smarthome.i18n

i'm not sure this is the only change needed. (not sure if this is needed at all...)